### PR TITLE
Adding change of SECRET_KEY in README to be able to run project locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ $ pip install -r requirements.txt
 ```
 
 ### Carregado os dados
+
+Altere o valor da variável `SECRET_KEY` no arquivo `./censo/settings.py` para um valor aleatório.
+
+Gere as migrations e importe os dados.
+
 ```
 $ python manage.py migrate
 $ python manage.py read_data --file data/municipal_data.csv


### PR DESCRIPTION
When I tried to run the project locally, I have received this error:

```
...
    if settings.USE_I18N:
  File "/home/jaswdr/.local/share/virtualenvs/censo-querido-diario--OuRbTDe/lib/python3.8/site-packages/django/conf/__init__.py", line 83, in __getattr__
    self._setup(name)
  File "/home/jaswdr/.local/share/virtualenvs/censo-querido-diario--OuRbTDe/lib/python3.8/site-packages/django/conf/__init__.py", line 70, in _setup
    self._wrapped = Settings(settings_module)
  File "/home/jaswdr/.local/share/virtualenvs/censo-querido-diario--OuRbTDe/lib/python3.8/site-packages/django/conf/__init__.py", line 196, in __init__
    raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.
```

This happens because the `SECRET_KEY` has an empty string value in the `censo/settings.py`, I'm adding a section in the README mentioning this in this PR.